### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Search for Go code using syntax trees. Work in progress.
 
-	gogrep 'if $x != nil { return $x, $*_ }'
+	gogrep -x 'if $x != nil { return $x, $*_ }'
 
 ### Instrucitons
 
@@ -19,8 +19,6 @@ A command is of the form "-A pattern", where -A is one of:
        -v  discard nodes matching a pattern
        -s  substitute with a given syntax tree
        -w  write source back to disk or stdout
-
-If -A is ommitted for a single command, -x will be assumed.
 
 A pattern is a piece of Go code which may include wildcards. It can be:
 


### PR DESCRIPTION
This PR updates example in README, which uses implicit '-x' command, which seems to be unsupported.

Maybe the right solution is to implement this feature back (assume `-x` command when no commands is specified), but a) it's a bit tricky with flagset design (we can't use `exprCmd` and will need to implement custom parsing/validation logic for this particular case) b) I'm not sure it's a good CLI design either – the more explicit behaviour, the better. So, anyway, this could be re-introduced back in the next PRs.