### PR TITLE
fix range stmt matching

### DIFF
--- a/match.go
+++ b/match.go
@@ -588,7 +588,13 @@ func (m *matcher) node(expr, node ast.Node) bool {
 			m.optNode(x.Post, y.Post) && m.node(x.Body, y.Body)
 	case *ast.RangeStmt:
 		y, ok := node.(*ast.RangeStmt)
-		return ok && m.node(x.Key, y.Key) && m.node(x.Value, y.Value) &&
+		if !ok {
+			return false
+		}
+		if !m.aggressive && x.Tok != y.Tok {
+			return false
+		}
+		return m.node(x.Key, y.Key) && m.node(x.Value, y.Value) &&
 			m.node(x.X, y.X) && m.node(x.Body, y.Body)
 
 	case *ast.TypeSpec:

--- a/match_test.go
+++ b/match_test.go
@@ -530,6 +530,8 @@ func TestMatch(t *testing.T) {
 		// for and range stmts
 		{[]string{"-x", "for $x { $y }"}, "for b { c() }", 1},
 		{[]string{"-x", "for $x := range $y { $z }"}, "for i := range l { c() }", 1},
+		{[]string{"-x", "for $x := range $y { $z }"}, "for i = range l { c() }", 0},
+		{[]string{"-x", "for $x = range $y { $z }"}, "for i := range l { c() }", 0},
 		{[]string{"-x", "for range $y { $z }"}, "for _, e := range l { e() }", 0},
 
 		// $*_ matching stmt+expr combos (ifs)


### PR DESCRIPTION
We also need to check Tok in non-aggressive mode,
so range:= and range= patterns match only respective statements.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>