### PR TITLE
Handle `*ast.KeyValueExpr` in `fromWildNode`

### DIFF
--- a/match.go
+++ b/match.go
@@ -1045,6 +1045,8 @@ func fromWildNode(node ast.Node) int {
 		if len(node.Names) == 0 && node.Tag == nil {
 			return fromWildNode(node.Type)
 		}
+	case *ast.KeyValueExpr:
+		return fromWildNode(node.Value)
 	}
 	return -1
 }

--- a/match_test.go
+++ b/match_test.go
@@ -500,6 +500,9 @@ func TestMatch(t *testing.T) {
 			[]string{"-x", "struct{$*_; Foo $t; $*_}"},
 			"type T struct{Foo string; a int; B}", 1,
 		},
+		// structure literal
+		{[]string{"-x", "struct{a int}{a: $_}"}, "struct{a int}{a: 1}", 1},
+		{[]string{"-x", "struct{a int}{a: $*_}"}, "struct{a int}{a: 1}", 1},
 
 		// value specs
 		{[]string{"-x", "$_ int"}, "var a int", 1},


### PR DESCRIPTION
Previously following match tests will get inconsistent result:

- `{[]string{"-x", "struct{a int}{a: $_}"}, "struct{a int}{a: 1}", 1}`: OK
- `{[]string{"-x", "struct{a int}{a: $*_}"}, "struct{a int}{a: 1}", 1}`: NOK

This is a quick fix while not sure if this makes sense. The cause why original code doesn't work for the 2nd test case is because when comparing `expr` (`*ast.Ident{Name: "gogrep_0"}`) and `node` (`*ast.BasicLit{Value: "1"}`) in `matcher.node()`, it will return `false` simply because the wildcard is `any`. I'm not sure the design behind this, so...